### PR TITLE
[CHORE] Adding config to avoid workflow concurrency

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,5 +1,9 @@
 name: Terraform
 
+concurrency:
+  group: terraform-${{ github.event.inputs.environment || 'dev' }}
+  cancel-in-progress: false
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Adding config to avoid workflow concurrency by environment to protect terraform state.